### PR TITLE
Add localStorage persistence for SRS card scheduling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
-        "@types/node": "^24.10.1",
+        "@types/node": "^24.10.4",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
-    "@types/node": "^24.10.1",
+    "@types/node": "^24.10.4",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",

--- a/src/components/SRS.tsx
+++ b/src/components/SRS.tsx
@@ -35,9 +35,14 @@ export const SRS = () => {
       });
       wordPhraseMapRef.current = map;
 
-      // Initialize SRS service with word phrase IDs
-      const wordPhraseIds = wordPhrasesData.map(wp => wp.id);
-      srsService.current.initializeCards(wordPhraseIds);
+      // Try to load from localStorage first
+      const loadedFromStorage = srsService.current.loadFromStorage();
+
+      // If no data in localStorage, initialize from JSON
+      if (!loadedFromStorage) {
+        const wordPhraseIds = wordPhrasesData.map(wp => wp.id);
+        srsService.current.initializeCards(wordPhraseIds);
+      }
 
       // Get cards that are due now
       const due = srsService.current.getDueCards();

--- a/src/services/srsService.ts
+++ b/src/services/srsService.ts
@@ -1,4 +1,5 @@
 import { createEmptyCard, fsrs, generatorParameters, Rating, type Card } from 'ts-fsrs';
+import { saveSRSCards, loadSRSCards } from './srsStorage';
 
 export interface SRSCard {
   card: Card;
@@ -9,12 +10,29 @@ export class SRSService {
   private fsrs = fsrs(generatorParameters());
   private cards: SRSCard[] = [];
 
-  // Initialize cards from word phrase IDs
+  // Initialize cards from word phrase IDs (used for first-time setup)
   initializeCards(wordPhraseIds: number[]): void {
     this.cards = wordPhraseIds.map(id => ({
       card: createEmptyCard(),
       wordPhraseId: id,
     }));
+    // Save initial state to localStorage
+    this.saveToStorage();
+  }
+
+  // Load cards from localStorage
+  loadFromStorage(): boolean {
+    const loadedCards = loadSRSCards();
+    if (loadedCards && loadedCards.length > 0) {
+      this.cards = loadedCards;
+      return true;
+    }
+    return false;
+  }
+
+  // Save cards to localStorage
+  saveToStorage(): void {
+    saveSRSCards(this.cards);
   }
 
   // Get all cards
@@ -65,6 +83,9 @@ export class SRSService {
       ...currentCard,
       card: updatedCard,
     };
+
+    // Persist to localStorage after grading
+    this.saveToStorage();
 
     return updatedCard;
   }

--- a/src/services/srsStorage.ts
+++ b/src/services/srsStorage.ts
@@ -1,0 +1,112 @@
+import type { Card } from 'ts-fsrs';
+import type { SRSCard } from './srsService';
+
+const STORAGE_KEY = 'srs_cards_v1';
+
+/**
+ * Serializable version of SRSCard for localStorage
+ */
+interface SerializedSRSCard {
+  card: {
+    due: string; // ISO date string
+    stability: number;
+    difficulty: number;
+    elapsed_days: number;
+    scheduled_days: number;
+    reps: number;
+    lapses: number;
+    state: number;
+    last_review?: string; // ISO date string
+  };
+  wordPhraseId: number;
+}
+
+/**
+ * Save SRS cards to localStorage
+ */
+export function saveSRSCards(cards: SRSCard[]): void {
+  try {
+    const serialized: SerializedSRSCard[] = cards.map(srsCard => ({
+      card: {
+        due: srsCard.card.due.toISOString(),
+        stability: srsCard.card.stability,
+        difficulty: srsCard.card.difficulty,
+        elapsed_days: srsCard.card.elapsed_days,
+        scheduled_days: srsCard.card.scheduled_days,
+        reps: srsCard.card.reps,
+        lapses: srsCard.card.lapses,
+        state: srsCard.card.state,
+        last_review: srsCard.card.last_review?.toISOString(),
+      },
+      wordPhraseId: srsCard.wordPhraseId,
+    }));
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(serialized));
+  } catch (error) {
+    console.error('Failed to save SRS cards to localStorage:', error);
+  }
+}
+
+/**
+ * Load SRS cards from localStorage
+ * Returns null if no data exists or if data is invalid
+ */
+export function loadSRSCards(): SRSCard[] | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+
+    const serialized: SerializedSRSCard[] = JSON.parse(stored);
+
+    // Validate the data structure
+    if (!Array.isArray(serialized)) {
+      console.warn('Invalid SRS data in localStorage: not an array');
+      return null;
+    }
+
+    const cards: SRSCard[] = serialized.map(item => ({
+      card: {
+        due: new Date(item.card.due),
+        stability: item.card.stability,
+        difficulty: item.card.difficulty,
+        elapsed_days: item.card.elapsed_days,
+        scheduled_days: item.card.scheduled_days,
+        reps: item.card.reps,
+        lapses: item.card.lapses,
+        state: item.card.state,
+        last_review: item.card.last_review ? new Date(item.card.last_review) : undefined,
+      } as Card,
+      wordPhraseId: item.wordPhraseId,
+    }));
+
+    return cards;
+  } catch (error) {
+    console.error('Failed to load SRS cards from localStorage:', error);
+    return null;
+  }
+}
+
+/**
+ * Clear all SRS data from localStorage
+ */
+export function clearSRSCards(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to clear SRS cards from localStorage:', error);
+  }
+}
+
+/**
+ * Check if SRS data exists in localStorage
+ */
+export function hasSRSData(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== null;
+  } catch (error) {
+    console.error('Failed to check for SRS data in localStorage:', error);
+    return false;
+  }
+}


### PR DESCRIPTION
Implements browser localStorage to persist SRS card scheduling data between sessions.

Key changes:
- Created srsStorage.ts utility for localStorage operations (save/load/clear)
- Updated SRSService to load from localStorage on init and save after each card grade
- Modified SRS component to check localStorage first, falling back to JSON initialization
- Added @types/node as dev dependency for TypeScript support

This allows users to continue their study sessions after refreshing the page,
maintaining all card scheduling data (due dates, repetitions, difficulty, etc.)